### PR TITLE
Formatting changes to pass markdownlint and minor changes to cluster creation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # RollingUpgrades
+
 > Reliable, extensible rolling-upgrades of Autoscaling groups in Kubernetes
 
 RollingUpgrades provides a Kubernetes native mechanism for doing rolling-updates of instances in an AutoScaling group using a CRD and a controller.
 
 ## What does it do?
 
-* RollingUpgrade is highly inspired by the way kops does rolling-updates.
+- RollingUpgrade is highly inspired by the way kops does rolling-updates.
 
-* It provides similar options for the rolling-updates as kops and more.
+- It provides similar options for the rolling-updates as kops and more.
 
-* The RollingUpgrade Kubernetes custom resource has the following options in the spec:
+- The RollingUpgrade Kubernetes custom resource has the following options in the spec:
   - `asgName`: Name of the autoscaling group to perform the rolling-update.
   - `region`: Name of the AWS region in which the ASG exists.
   - `preDrain.script`: The script to run before draining a node.
@@ -19,7 +20,7 @@ RollingUpgrades provides a Kubernetes native mechanism for doing rolling-updates
   - `nodeIntervalSeconds`: The amount of time in seconds to wait after each node in the ASG is terminated.
   - `postTerminate.script`: Optional bash script to execute after the node has terminated.
 
-* After performing the rolling-update of the nodes in the ASG, RollingUpgrade puts the following data in the "Status" field.
+- After performing the rolling-update of the nodes in the ASG, RollingUpgrade puts the following data in the "Status" field.
   - `currentStatus`: Whether the rolling-update completed or errored out.
   - `startTime`: The RFC3339 timestamp when the rolling-update began. E.g. 2019-01-15T23:51:10Z
   - `endTime`: The RFC3339 timestamp when the rolling-update completed. E.g. 2019-01-15T00:35:10Z
@@ -30,6 +31,7 @@ RollingUpgrades provides a Kubernetes native mechanism for doing rolling-updates
 For each RollingUprade custom resource that is submitted, the following flowchart shows the sequence of actions taken to [perform the rolling-update](docs/RollingUpgradeDesign.png)
 
 ## Dependencies
+
 - Kubernetes cluster on AWS with nodes in AutoscalingGroups. rolling-upgrades have been tested with Kubernetes clusters v1.12+.
 - An IAM role with at least the policy specified below. The upgrade-manager should be run with that IAM role.
 
@@ -43,13 +45,14 @@ For a complete, step by step guide for creating a cluster with kops, editing it 
 
 If you already have an existing cluster created using kops, follow the instructions below.
 
-* Ensure that you have a Kubernetes cluster on AWS.
-* Install the CRD using: `kubectl apply -f config/crd/bases`
-* Install the controller using:
+- Ensure that you have a Kubernetes cluster on AWS.
+- Install the CRD using: `kubectl apply -f config/crd/bases`
+- Install the controller using:
 `kubectl create -f deploy/rolling-upgrade-controller-deploy.yaml`
 
-* Note that the rolling-upgrade controller requires an IAM role with the following policy
-```
+- Note that the rolling-upgrade controller requires an IAM role with the following policy
+
+``` json
 {
     "Effect": "Allow",
     "Action": [
@@ -62,6 +65,7 @@ If you already have an existing cluster created using kops, follow the instructi
     ]
 }
 ```
+
 - If the rolling-upgrade controller is directly using the IAM role of the node it runs on, the above policy will have to be added to the IAM role of the node.
 - If the rolling-upgrade controller is using it's own role created using KIAM, that role should have the above policy in it.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,7 @@
 # Frequently Asked Questions
 
 ## What happens when:
+
 _1. Draining of a node fails?_
 
 RollingUpgrade logs will show the reason why the drain failed (output of `kubectl drain`). It then marks the custom resource status as "error". After marking the object status as "error", the rolling-upgrade controller will ignore the object.
@@ -20,6 +21,7 @@ _3. RollingUpgrade controller gets terminated while it was performing the rollin
 - Then, the rolling-upgrade controller resumes performing the rolling-updates from where it left. Care is taken to ensure that if any nodes had already been updated, they won't go through the update again.
 
 ## Other details
+
 _1. Instead of rolling-upgrade controller, why not simply run `kops rolling-update` in a container on the master node?_
 
 - kops does not provide additional hooks for `preDrain`, `postDrain` or `postTerminate`, etc.
@@ -49,5 +51,3 @@ _5. What are the specific cases where the preDrain, postDrain, postDrainWait and
 - postDrain: This could be used to ensure that all the pods on that node (or maybe all pods in the cluster) have been successfully scheduled on a different node/s. Additional sleeps could be added to ensure that this condition is being met. In case there are no other nodes in the cluster to run the pods, this script could also add more nodes in the cluster (or wait for cluster-autoscaler to spin-up the nodes). Also, any additional "draining" actions required on the node could be performed here. E.g. The node could be taken out of the target group of ALB by adding an additional label to the node.
 - postDrainWait: This could be used to ensure that all pods that have migrated to different nodes are actually running and service client requests.
 - postTerminate: This is executed after an ec2 instance is terminated and the `nodeIntervalSeconds` have passed. In the postTerminate script, additional checks such as ensuring that all the nodes (including the newly created one) has successfully joined the cluster can be performed.
-
-

--- a/docs/step-by-step-example.md
+++ b/docs/step-by-step-example.md
@@ -85,7 +85,10 @@ kops update cluster ${CLUSTER_NAME} --yes
 ```
 
 * Create an IAM policy using the document above.
-`$ aws iam create-policy --policy-name rolling-upgrade-policy --policy-document file:///tmp/rolling-upgrade-policy`
+
+```
+$ aws iam create-policy --policy-name rolling-upgrade-policy --policy-document file:///tmp/rolling-upgrade-policy
+```
 
 * This will output a bunch of details such as
 
@@ -109,7 +112,9 @@ kops update cluster ${CLUSTER_NAME} --yes
 * The "Arn" field from the above output is required in the next command.
 * Attach this policy to the role of the Kubernetes master nodes using the Arn from above. The role-name is `masters.<name of the cluster used in the kops script above>`
 
-`$ aws iam attach-role-policy --role-name masters.test-cluster-kops.cluster.k8s.local --policy-arn arn:aws:iam::0123456789:policy/rolling-upgrade-policy`
+```
+$ aws iam attach-role-policy --role-name masters.test-cluster-kops.cluster.k8s.local --policy-arn arn:aws:iam::0123456789:policy/rolling-upgrade-policy
+```
 
 ### Install the rolling-upgrade-controller
 

--- a/docs/step-by-step-example.md
+++ b/docs/step-by-step-example.md
@@ -2,9 +2,9 @@
 
 This guide will provide a step by step walkthrough for creating a Kubernetes cluster with Instance Groups and then upgrading those using this rolling-upgrade-controller.
 
-### Create a Kubernetes cluster using kops
+## Create a Kubernetes cluster using kops
 
-#### Prerequisites
+### Prerequisites
 
 * Ensure that you have AWS credentials downloaded. A simple test is to run `aws s3 ls` and ensure that you have some output.
 * Ensure that you have at least 1 S3 bucket ready for using the [kops state store](https://github.com/kubernetes/kops/blob/master/docs/state.md)
@@ -12,7 +12,7 @@ This guide will provide a step by step walkthrough for creating a Kubernetes clu
 * Ensure that the kubectl executable is ready to be used. A simple tests for this is to run `kubectl version` and ensure that output shows the client version.
 * Copy the following script into a local file; say `/tmp/create_cluster.sh`
 
-```bash
+``` bash
 #!/bin/bash
 
 set -ex
@@ -31,13 +31,13 @@ kops create cluster \
 --node-count=2 \
 --zones=us-west-2a,us-west-2b,us-west-2c \
 --master-zones=us-west-2c \
---node-size=c4.large \
---master-size=c4.large \
+--node-size=c5.large \
+--master-size=c5.large \
 --master-count=1 \
 --networking=calico \
 --topology=private \
 --ssh-public-key=~/.ssh/id_rsa.pub \
---kubernetes-version=1.13.5
+--kubernetes-version=1.13.9
 
 kops create secret --name ${CLUSTER_NAME} sshpublickey admin -i ~/.ssh/id_rsa.pub
 
@@ -45,27 +45,27 @@ kops update cluster ${CLUSTER_NAME} --yes
 
 ```
 
-#### Actually create the cluster
+### Actually create the cluster
 
 * Create the cluster by running the script above as follows:
-    * Edit the cluster name by modifying the CLUSTER_NAME variable in the scrip above if needed.
-    * Change `my-bucket-name` below with the actual name of your s3 bucket.
- 
+  * Edit the cluster name by modifying the CLUSTER_NAME variable in the scrip above if needed.
+  * Change `my-bucket-name` below with the actual name of your s3 bucket.
+
 `$ KOPS_STATE_STORE=s3://my-bucket-name /tmp/create_cluster.sh`
 
 * This takes several minutes for the cluster to actually come up.
 * Ensure that the cluster is up by running the command `kubectl cluster-info`. You should see some information like the url for the master and maybe endpoint for KubeDNS.
 * Congratulations! Your Kubernetes cluster is ready and can be now used for testing.
 
-### Run the rolling-upgrade-manager
+## Run the rolling-upgrade-manager
 
-#### Update the IAM role for the rolling-upgrade-controller
+### Update the IAM role for the rolling-upgrade-controller
 
 * Before we actually install the rolling-upgrade-controller, we need make sure that the IAM that will be used has enough privileges for the rolling-upgrade-controller to work.
 * To do this, let's edit the IAM role used by the master nodes in the above cluster.
 * Copy the following into a file; say `/tmp/rolling-upgrade-policy`
 
-```
+``` json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -77,7 +77,7 @@ kops update cluster ${CLUSTER_NAME} --yes
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
             "Resource": [
-             "*"
+                "*"
             ]
         }
     ]
@@ -89,7 +89,7 @@ kops update cluster ${CLUSTER_NAME} --yes
 
 * This will output a bunch of details such as
 
-```
+``` json
 {
     "Policy": {
         "PolicyName": "rolling-upgrade-policy",
@@ -105,21 +105,22 @@ kops update cluster ${CLUSTER_NAME} --yes
     }
 }
 ```
+
 * The "Arn" field from the above output is required in the next command.
 * Attach this policy to the role of the Kubernetes master nodes using the Arn from above. The role-name is `masters.<name of the cluster used in the kops script above>`
 
 `$ aws iam attach-role-policy --role-name masters.test-cluster-kops.cluster.k8s.local --policy-arn arn:aws:iam::0123456789:policy/rolling-upgrade-policy`
 
-#### Install the rolling-upgrade-controller
+### Install the rolling-upgrade-controller
 
 * Install the CRD using: `$ kubectl apply -f config/crd/bases`
 * Install the controller using:
 `$ kubectl create -f deploy/rolling-upgrade-controller-deploy.yaml`
 * Ensure that the rolling-upgrade-controller deployment is running.
 
-### Actually perform rolling-upgrade of one InstanceGroup
+## Actually perform rolling-upgrade of one InstanceGroup
 
-#### Update the nodes AutoScalingGroup 
+### Update the nodes AutoScalingGroup
 
 * Update the `nodes` instance-group so that it needs a rolling-upgrade. The following command will open the specification for the nodes instance-group in an editor. Change the instance type from `c4.large` to `r4.large`.
 `$ KOPS_STATE_STORE=s3://my-bucket-name kops edit ig nodes`
@@ -127,11 +128,11 @@ kops update cluster ${CLUSTER_NAME} --yes
 * The run kops upgrade to make these changes persist and have kops modify the ASG's launch configuration
 `$ KOPS_STATE_STORE=s3://my-bucket-name kops update cluster --yes`
 
-#### Create the RollingUpgrade custom-resource (CR) that will actually do the rolling-upgrade.
+### Create the RollingUpgrade custom-resource (CR) that will actually do the rolling-upgrade.
 
 * Run the following script:
 
-```
+``` bash
 #!/bin/bash
 
 set -ex
@@ -165,16 +166,16 @@ EOF
 kubectl create -f /tmp/crd.yaml
 ```
 
-#### Ensure nodes are getting updated
+### Ensure nodes are getting updated
 
 * As soon as the above CR is submitted, the rolling-upgrade-controller will pick it up and start the rolling-upgrade process.
 * There are multiple ways to ensure that rolling-upgrades are actually happening.
-    * Watch the AWS console. Existing nodes should be seen getting Terminated. New nodes coming up should be of type r4.large.
-    * Run `kubectl get nodes`. Some node will either have SchedulingDisabled or it could be terminated and new node should be seen coming up.
-    * Check the status in the actual CR. It has details of how many nodes are going to be upgraded and how many have been completed. `$ kubectl get rollingupgrade -o yaml`
+  * Watch the AWS console. Existing nodes should be seen getting Terminated. New nodes coming up should be of type r4.large.
+  * Run `kubectl get nodes`. Some node will either have SchedulingDisabled or it could be terminated and new node should be seen coming up.
+  * Check the status in the actual CR. It has details of how many nodes are going to be upgraded and how many have been completed. `$ kubectl get rollingupgrade -o yaml`
 * Checks the logs of the rolling-upgrade-controller for minute details of how the CR is being processed.
 
-### Deleting the cluster
+## Deleting the cluster
 
 * Before deleting the cluster, the policy that was created explicitly will have to be deleted.
 
@@ -186,4 +187,3 @@ $ aws iam delete-policy --policy-arn arn:aws:iam::0123456789:policy/rolling-upgr
 * Now delete the cluster
 
 `$ KOPS_STATE_STORE=s3://my-bucket-name kops delete cluster test-cluster-kops.cluster.k8s.local --yes`
-


### PR DESCRIPTION
Update kubernetes version to 1.13.9 and instance type to c5.large in cluster creation example. Other minor formatting changes to pass markdownlint.